### PR TITLE
Update choose-domain-to-create-groups.md

### DIFF
--- a/Office365-Admin/create-groups/choose-domain-to-create-groups.md
+++ b/Office365-Admin/create-groups/choose-domain-to-create-groups.md
@@ -106,7 +106,7 @@ There are a few more things to know:
   
 - How fast groups are created depends on the number of EAPs configured in your organization.
     
-- Users will not be able to modify domains when they create Office 365 groups. Only admins can specify the domain that the group can be created in.
+- Admins and users can also modify domains when they create Office 365 groups.
     
 - Group of users is determined using the standard queries (User properties) that are already available. Check out [Filterable properties for the -RecipientFilter parameter](https://go.microsoft.com/fwlink/p/?LinkId=785918) for supported filterable pproperties. 
     


### PR DESCRIPTION
As a client has opened an issue that the user can't select the domain while creating the office365 groups. I have tested it and found that the user can select the domain he wants to use to create office 365 groups.