### PR TITLE
Update set-up-file-storage-and-sharing.md

### DIFF
--- a/Office365-Admin/setup/set-up-file-storage-and-sharing.md
+++ b/Office365-Admin/setup/set-up-file-storage-and-sharing.md
@@ -35,7 +35,9 @@ description: "Learn how to use OneDrive for Business and a team site for file st
 One of the best ways to set up file storage and sharing for your business is to use OneDrive for Business and a team site together. This is ideal if you have a small business with a few employees.
   
 Office 365 includes a basic team site for you to get started. You can immediately start storing files in OneDrive and collaborating on files in the team site.
-  
+
+> [!NOTE]
+> The basic team site is still provided but is now hidden. It can only be accessed from the Office 365 admin center or the SharePoint Online admin center.
   
 ## Where you can store documents in Office 365
 


### PR DESCRIPTION
Added note to clarify use of  the term: "basic team site" which is confusing as per https://github.com/MicrosoftDocs/OfficeDocs-O365ITPro/issues/170 as the site is there but hidden and should actually not be mentioned at all. The whole article may need revision along with https://docs.microsoft.com/office365/admin/setup/cutomize-team-site/ which mentions a "classic team site" which is also not accessible to most users and is confusing as, like the "basic team site" it predates, is not related to Microsoft Teams at all - now that Teams exists, the obvious association is with the site created on SharePoint when you create a Team on Teams. so it IS confusing.