### PR TITLE
License for naming policy

### DIFF
--- a/Office365-Admin/create-groups/groups-naming-policy.md
+++ b/Office365-Admin/create-groups/groups-naming-policy.md
@@ -40,7 +40,7 @@ The group naming policy consists of the following features:
     
 ## Licensing requirements
 
-To use the Groups naming policy feature, the following people need an Azure Active Directory Premium P1 license or Azure AD Basic EDU license:
+To use the Groups naming policy feature, the following people need an Azure Active Directory Premium P1 license :
 - Everyone who is a member of the group.
 - The person who creates the group.
 - The admin who creates the Groups naming policy  


### PR DESCRIPTION
Based on Pricing details table on https://azure.microsoft.com/en-us/pricing/details/active-directory/, advanced group features including naming policy are not available with Azure AD Basic.