### PR TITLE
Fix Typo on Link

### DIFF
--- a/Office365-Admin/setup/domains-faq.md
+++ b/Office365-Admin/setup/domains-faq.md
@@ -326,7 +326,7 @@ You can keep using the initial onmicrosoft.de domain even after you add your dom
 
 ## How do I verify my nonprofit or education status?
 
-1. Choose **Setup** in the [Microsoft 365 admin center](https://support.office.com/article/17d3ff3f-3601-466e-b5a1-482b31cfb791 .aspx) to start the wizard. (Be sure to sign in to Office 365 first.) 
+1. Choose **Setup** in the [Microsoft 365 admin center](https://support.office.com/article/17d3ff3f-3601-466e-b5a1-482b31cfb791.aspx) to start the wizard. (Be sure to sign in to Office 365 first.) 
     
 2. To become the Office 365 admin for your school, [follow these steps](https://go.microsoft.com/fwlink/?LinkId=512141) to find and choose the **Become an admin** option in Office 365. 
     


### PR DESCRIPTION
Fix a typo which breaks a link in the "How do I verify my nonprofit or education status?" section of the Domain FAQ.

The line contained a space, causing the markdown to not render the link correctly.