### PR TITLE
Clear up the Licensing requirements

### DIFF
--- a/Office365-Admin/create-groups/groups-naming-policy.md
+++ b/Office365-Admin/create-groups/groups-naming-policy.md
@@ -40,10 +40,8 @@ The group naming policy consists of the following features:
     
 ## Licensing requirements
 
-To use the Groups naming policy feature, the following people need an Azure Active Directory Premium P1 license or Azure AD Basic EDU license:
-- Everyone who is a member of the group.
-- The person who creates the group.
-- The admin who creates the Groups naming policy  
+Using Azure AD naming policy for Office 365 groups requires that you possess but not necessarily assign an Azure Active Directory Premium P1 license or Azure AD Basic EDU license for each unique user (including guests) that is a member of one or more Office 365 groups.
+This is also required for the administrator that creates the Groups naming policy.
 
 ## Prefix-Suffix Naming policy
 


### PR DESCRIPTION
I think the requirements are a bit misleading, so I changed the text a bit to match:
https://docs.microsoft.com/en-us/azure/active-directory/users-groups-roles/groups-naming-policy