### PR TITLE
Update office-365-groups-expiration-policy.md

### DIFF
--- a/Office365-Admin/create-groups/office-365-groups-expiration-policy.md
+++ b/Office365-Admin/create-groups/office-365-groups-expiration-policy.md
@@ -63,7 +63,7 @@ If you have setup retention policy in Security and Compliance center for groups,
 
 ## How and when a Group owner learns if their Groups are going to expire
 
-Group owners will only be notified via email, except for groups created via Teams. If the group was created via Planner, SharePoint, or any other app, the expiration notifications will always come via email. If the group was created via Teams, the group owner will receive a notification to renew through the activity section. It's not recommended that you enable expiration on a group if your group owner doesn't have a valid email address.
+Group owners will only be notified via email. If the group was created via Planner, SharePoint, or any other app, the expiration notifications will always come via email. If the group was created via Teams, the group owner will receive a notification to renew through the activity section. It's not recommended that you enable expiration on a group if your group owner doesn't have a valid email address.
 
 30 days before the group expires, the group owners (or the email addresses that you specified for groups that don't have an owner) will receive an email allowing them to easily renew the group. If they don't renew it, they'll receive another renewal email 15 days before expiration. If they still haven't renewed it, they will receive one more email notification the day before expiration.
 


### PR DESCRIPTION
At line 66 removed "except for groups created via Team".  Owners of groups created via Teams do receive an email AND they get the activity in their Teams Activity Feed.  So unclear why it says "except for groups created via Teams" = therefore removed same.