### PR TITLE
Update data deletion period for ExO

### DIFF
--- a/Office365-Admin/subscriptions-and-billing/cancel-your-subscription.md
+++ b/Office365-Admin/subscriptions-and-billing/cancel-your-subscription.md
@@ -102,7 +102,7 @@ For more information, see [How does Office 365 manage my DNS records?](../setup/
 
 ### Save your data
 
-When the cancellation becomes effective, your users lose access to their dat. Before you cancel the subscription, have them save their OneDrive for Business or SharePoint Online files to another location. Any customer data that you leave behind might be deleted after 90 days, and is deleted no later than 180 days after cancellation.
+When the cancellation becomes effective, your users lose access to their dat. Before you cancel the subscription, have them save their OneDrive for Business or SharePoint Online files to another location. Any customer data that you leave behind might be deleted after 30 days, and is deleted no later than 180 days after cancellation.
 
 - To move email, contacts, tasks, and calendar information to another account, see [Export or backup email, contacts, and calendar to an Outlook .pst file](https://support.office.com/article/14252b52-3075-4e9b-be4e-ff9ef1068f91.aspx).
 


### PR DESCRIPTION
Customer asked us about exchange mailbox data has been purged after 30 days (before 90 days). From customer escalation, the data might be deleted 30 days period. (normally EXO mailbox data has been deleted after subscription removed)
Current document, the customer data seems to be kept during 90 days after subscription canceled. So it need to be modified.

from the bug
---
https://o365exchange.visualstudio.com/DefaultCollection/O365%20Core/_workitems/edit/1245373
However, based on the description, it looks like, if customer previously had a mailbox, they performed some action on July 4th (the 30 days limit was then probably reached) and the mailbox was then hard deleted (unrecoverable).