### PR TITLE
Removing central deployment to Office Online Server not being possible

### DIFF
--- a/Office365-Admin/manage/centralized-deployment-of-add-ins.md
+++ b/Office365-Admin/manage/centralized-deployment-of-add-ins.md
@@ -36,9 +36,7 @@ Centralized Deployment doesn't support the following:
     
 - An on-premises directory service
     
-- Add-in deployment to SharePoint
-    
-- Add-in deployment to Office Online Server
+- Add-in deployment to SharePoint  
 
 - Teams apps
    


### PR DESCRIPTION
Just successfully deployed a Word add-in from Office 365 through central deployment and it perfectly shows up in Office Online server, so removing the statement that this scenario would not work.