### PR TITLE
Update auto-acceleration-policy-for-signing-in.md

### DIFF
--- a/yammer/manage-yammer-users/auto-acceleration-policy-for-signing-in.md
+++ b/yammer/manage-yammer-users/auto-acceleration-policy-for-signing-in.md
@@ -89,7 +89,7 @@ To improve the Office 365 sign-in experience for Yammer, use the Auto-accelerati
 5. Note **ObjectId** of servicePrincipal for Yammer application (Redirect output to a text file for easy search). The AppDisplayName would be "Office 365 Yammer" with AppID of 00000005-00000ff1-ce00-000000000000 
     
     ```powershell
-    Get-AzureADServicePrincipal | fl > output.txt
+    Get-AzureADServicePrincipal -All $true | fl > output.txt
     ```
     ![Command line for redirecting output to a text file](../media/31fee97b-75a2-498e-b404-c925f018615f.jpg)
 
@@ -114,7 +114,7 @@ $PolicyId = New-AzureADPolicy -Definition
 @("{`"HomeRealmDiscoveryPolicy`":{`"AccelerateToFederatedDomain`"
 :true}}") -DisplayName BasicAutoAccelerationPolicyforYammer -Type HomeRealmDiscoveryPolicy
 get-AzureADPolicy
-$yamObjectId = Get-AzureADServicePrincipal | ?{$_.AppDisplayName -eq 'Office 365 Yammer'}
+$yamObjectId = Get-AzureADServicePrincipal -All $true | ?{$_.AppDisplayName -eq 'Office 365 Yammer'}
 Add-AzureADServicePrincipalPolicy -Id $yamObjectId.ObjectId - RefObjectId $PolicyId.Id
 ```
 


### PR DESCRIPTION
To retrieve the servicePrincipal for the Yammer application, the parameter -All must be used when invoking Get-AzureADServicePrincipal