### PR TITLE
Fixed broken links on various articles

### DIFF
--- a/Office365-Admin/dns/create-dns-records-at-1-1-internet.md
+++ b/Office365-Admin/dns/create-dns-records-at-1-1-internet.md
@@ -29,7 +29,7 @@ description: "Learn to verify your domain and set up DNS records for email, Skyp
   
 After you add these records at 1&1 IONOS, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-123-reg-co-uk.md
+++ b/Office365-Admin/dns/create-dns-records-at-123-reg-co-uk.md
@@ -28,7 +28,7 @@ If 123-reg.co.uk is your DNS hosting provider, follow the steps in this article 
   
 After you add these records at 123-reg.co.uk, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-aws.md
+++ b/Office365-Admin/dns/create-dns-records-at-aws.md
@@ -28,7 +28,7 @@ If AWS is your DNS hosting provider, follow the steps in this article to verify 
   
 After you add these records at AWS, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-bluehost.md
+++ b/Office365-Admin/dns/create-dns-records-at-bluehost.md
@@ -28,7 +28,7 @@ If Bluehost is your DNS hosting provider, follow the steps in this article to ve
   
 After you add these records at Bluehost, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-crazy-domains.md
+++ b/Office365-Admin/dns/create-dns-records-at-crazy-domains.md
@@ -28,7 +28,7 @@ If Crazy Domains is your DNS hosting provider, follow the steps in this article 
   
 After you add these records at Crazy Domains, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-dnsmadeeasy.md
+++ b/Office365-Admin/dns/create-dns-records-at-dnsmadeeasy.md
@@ -28,7 +28,7 @@ If DNSMadeEasy is your DNS hosting provider, follow the steps in this article to
   
 After you add these records at DNSMadeEasy, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-dyn-com.md
+++ b/Office365-Admin/dns/create-dns-records-at-dyn-com.md
@@ -26,7 +26,7 @@ description: "Learn to verify your domain and set up DNS records for email, Skyp
   
 If Dyn.com is your DNS hosting provider, follow the steps in this article to verify your domain and set up DNS records for email, Skype for Business Online, and so on.
  
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 >  Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-enomcentral.md
+++ b/Office365-Admin/dns/create-dns-records-at-enomcentral.md
@@ -28,7 +28,7 @@ If eNomCentral is your DNS hosting provider, follow the steps in this article to
   
 After you add these records at eNomCentral, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 >  Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-godaddy.md
+++ b/Office365-Admin/dns/create-dns-records-at-godaddy.md
@@ -29,7 +29,7 @@ If GoDaddy is your DNS hosting provider, follow the steps in this article to ver
 
 After you add these records at GoDaddy, your domain will be set up to work with Office 365 services.
 
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
 
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md).

--- a/Office365-Admin/dns/create-dns-records-at-google-domains.md
+++ b/Office365-Admin/dns/create-dns-records-at-google-domains.md
@@ -28,7 +28,7 @@ If Google Domains is your DNS hosting provider, follow the steps in this article
   
 After you add these records at Google Domains, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-hostgator.md
+++ b/Office365-Admin/dns/create-dns-records-at-hostgator.md
@@ -31,7 +31,7 @@ If Hostgator is your DNS hosting provider, follow the steps in this article to v
 
 After you make all of these changes at Hostgator, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-hover.md
+++ b/Office365-Admin/dns/create-dns-records-at-hover.md
@@ -28,7 +28,7 @@ If Hover is your DNS hosting provider, follow the steps in this article to verif
      
 After you add these records at Hover, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 >  Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-mydomain.md
+++ b/Office365-Admin/dns/create-dns-records-at-mydomain.md
@@ -33,7 +33,7 @@ If you choose to manage your own Office 365 DNS records at MyDomain despite the 
     
 After you add these records at MyDomain, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-name-com.md
+++ b/Office365-Admin/dns/create-dns-records-at-name-com.md
@@ -28,7 +28,7 @@ If name.com is your DNS hosting provider, follow the steps in this article to ve
   
 After you add these records at name.com, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-names-co-uk.md
+++ b/Office365-Admin/dns/create-dns-records-at-names-co-uk.md
@@ -28,7 +28,7 @@ If Names.co.uk is your DNS hosting provider, follow the steps in this article to
     
 After you add these records at Names.co.uk, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 >  Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-network-solutions.md
+++ b/Office365-Admin/dns/create-dns-records-at-network-solutions.md
@@ -40,7 +40,7 @@ These are the main records to add. Follow the steps below or [watch the video](h
     
 After you add these records at Network Solutions, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 >  Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-register-com.md
+++ b/Office365-Admin/dns/create-dns-records-at-register-com.md
@@ -40,7 +40,7 @@ These are the main records to add. Follow the steps below or [watch the video](h
     
 After you add these records at Register.com, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 > Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Find and fix issues after adding your domain or DNS records in Office 365](../get-help-with-domains/find-and-fix-issues.md). 

--- a/Office365-Admin/dns/create-dns-records-at-register365.md
+++ b/Office365-Admin/dns/create-dns-records-at-register365.md
@@ -40,7 +40,7 @@ These are the main records to add.
     
 After you add these records at Office 365, your domain will be set up to work with Office 365 services.
   
-To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx).
+To learn about webhosting and DNS for websites with Office 365, see [Use a public website with Office 365](https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9).
   
 > [!NOTE]
 >  Typically it takes about 15 minutes for DNS changes to take effect. However, it can occasionally take longer for a change you've made to update across the Internet's DNS system. If you're having trouble with mail flow or other issues after adding DNS records, see [Troubleshoot issues after changing your domain name or DNS records](../get-help-with-domains/find-and-fix-issues.md). 


### PR DESCRIPTION
Resolves #931 

Replaced the broken link -  https://support.office.com/article/a8178510-501d-4bd8-9921-b04f2e9517a5.aspx for the Link Text: Use a public website with Office 365 to **https://support.office.com/article/choose-a-public-website-3325d50e-d131-403c-a278-7f3296fe33a9**

**Affected articles:**

create-dns-records-at-1-1-internet.md
create-dns-records-at-123-reg-co-uk.md
create-dns-records-at-aws.md
create-dns-records-at-bluehost.md
create-dns-records-at-crazy-domains.md
create-dns-records-at-dnsmadeeasy.md
create-dns-records-at-dyn-com.md
create-dns-records-at-enomcentral.md
create-dns-records-at-godaddy.md
create-dns-records-at-google-domains.md
create-dns-records-at-hostgator.md
create-dns-records-at-hover.md
create-dns-records-at-mydomain.md
create-dns-records-at-name-com.md
create-dns-records-at-names-co-uk.md
create-dns-records-at-network-solutions.md
create-dns-records-at-register365.md
create-dns-records-at-register-com.md