### PR TITLE
Altering TIP regarding change of user UPN

### DIFF
--- a/Office365-Admin/add-users/change-a-user-name-and-email-address.md
+++ b/Office365-Admin/add-users/change-a-user-name-and-email-address.md
@@ -243,7 +243,7 @@ Set-MsolUserPrincipalName -UserPrincipalName anne.wallace@contoso.onmicrosoft.co
 ```
 
 > [!TIP]
-> This changes the person's **userPrincipalName** attribute and has no bearing on their email address. It is best practice, however, to have the person's logon UPN match their primary SMTP address. 
+> This changes the person's **userPrincipalName** attribute and has no bearing on their MOERA email address. It is best practice, however, to have the person's logon UPN match their primary SMTP address. 
   
 To learn how to change someone's username in Active Directory, in Windows Server 2003 and earlier, see [Rename a user account](https://go.microsoft.com/fwlink/?LinkId=809091).
   

--- a/Office365-Admin/add-users/change-a-user-name-and-email-address.md
+++ b/Office365-Admin/add-users/change-a-user-name-and-email-address.md
@@ -243,7 +243,7 @@ Set-MsolUserPrincipalName -UserPrincipalName anne.wallace@contoso.onmicrosoft.co
 ```
 
 > [!TIP]
-> This changes the person's **userPrincipalName** attribute and has no bearing on their MOERA email address. It is best practice, however, to have the person's logon UPN match their primary SMTP address. 
+> This changes the person's **userPrincipalName** attribute and has no bearing on their Microsoft Online Email Routing Address (MOERA) email address. It is best practice, however, to have the person's logon UPN match their primary SMTP address. 
   
 To learn how to change someone's username in Active Directory, in Windows Server 2003 and earlier, see [Rename a user account](https://go.microsoft.com/fwlink/?LinkId=809091).
   


### PR DESCRIPTION
Line 246
The tip states that the change of a user's UPN will have no bearing on their email address. Suggest that it's specified that no change will happen to the MOERA email address, or that the tip it is removed altogether since this is false.
Altering a user's UPN will currently trigger a recalculation of the proxyAddresses, and it will include the new UPN as either a secondary or primary SMTP depending on additional circumstances.